### PR TITLE
remove return statement from useScrollToTop hook

### DIFF
--- a/src/hooks/useScrollToTop.ts
+++ b/src/hooks/useScrollToTop.ts
@@ -7,6 +7,4 @@ export const useScrollToTop = () => {
     useEffect(() => {
       window.scrollTo(0, 0);
     }, [pathname]);
-  
-    return null;
   };


### PR DESCRIPTION
Removed return statement from useScrollToTop hook.
No other custom hook using the same smell could be found