### PR TITLE
fix: Tags component uses className instead of classname

### DIFF
--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -2,11 +2,11 @@ import { PropsWithChildren } from "react";
 
 export function Tags({
     children,
-    classname,
-  }: PropsWithChildren<{ classname?: string }>) {
+    className,
+  }: PropsWithChildren<{ className?: string }>) {
     return (
       <p
-        className={`font-publicSans font-bold text-[0.805rem] lg:text-base text-slightly-desaturated-cyan py-[0.3rem] ${classname}`}
+        className={`font-publicSans font-bold text-[0.805rem] lg:text-base text-slightly-desaturated-cyan py-[0.3rem] ${className}`}
       >
         {children}
       </p>

--- a/src/pages/portfolio/Bookmark.tsx
+++ b/src/pages/portfolio/Bookmark.tsx
@@ -35,10 +35,10 @@ export function Bookmark() {
                 and JavaScript for the areas that required interactivity, such
                 as the features section.
               </TextBlock>
-              <Tags classname="mb-0 md:mt-3 lg:mt-0 lg:mb-3">
+              <Tags className="mb-0 md:mt-3 lg:mt-0 lg:mb-3">
                 Interaction Design / Front End Development
               </Tags>
-              <Tags classname="mb-6 md:mb-4 lg:mb-7">HTML / CSS / JS</Tags>
+              <Tags className="mb-6 md:mb-4 lg:mb-7">HTML / CSS / JS</Tags>
               <ProjectLink to="https://www.frontendmentor.io/profile/Simplify4Me2" className="mb-6">VISIT WEBSITE</ProjectLink>
             </div>
             <TextBlock


### PR DESCRIPTION
Fixes #13

## Changes
- Rename `classname` prop to `className` in Tags component to follow React naming conventions
- Update all callers in Bookmark.tsx

## Rationale
The Tags component was using a non-standard prop name (`classname` with lowercase 'n') instead of the React convention (`className`). This caused confusion for developers and could lead to silent bugs if someone tried to use the standard `className` prop.