### PR TITLE
perf: use picture element to fix triple image download

### DIFF
--- a/src/images/Image.tsx
+++ b/src/images/Image.tsx
@@ -12,43 +12,15 @@ export function Image({
   alt,
 }: ImageProps) {
   return (
-    <>
+    <picture>
+      <source media="(min-width: 1024px)" srcSet={desktopImage} />
+      <source media="(min-width: 768px)" srcSet={tabletImage} />
       <img
         src={mobileImage}
-        alt={`${alt} image`}
-        className="md:hidden h-fit self-center"
+        alt={alt}
+        className="h-fit self-center"
         loading="lazy"
       />
-      <img
-        src={tabletImage}
-        alt={`${alt} image`}
-        className="hidden md:block lg:hidden h-fit self-center"
-        loading="lazy"
-      />
-      <img
-        src={desktopImage}
-        alt={`${alt} image`}
-        className="hidden lg:block h-fit self-center"
-        loading="lazy"
-      />
-    </>
+    </picture>
   );
 }
-
-
-
-// TODO: Refactor the ProfileImage component to use the srcSet attribute
-// import ProfileMobileImage from "../assets/homepage/mobile/image-homepage-profile.jpg";
-// import ProfileTabletImage from "../assets/homepage/tablet/image-homepage-profile.jpg";
-// import ProfileDesktopImage from "../assets/homepage/desktop/image-homepage-profile.jpg";
-
-// export function ProfileImage() {
-//     return (
-//       <img
-//         src={ProfileMobileImage}
-//         srcSet={`${ProfileMobileImage} 320w, ${ProfileTabletImage} 768w, ${ProfileDesktopImage} 1280w`}
-//         sizes="(max-width: 640px) 100%, (max-width: 768px) 100%, 100%"
-//         alt="homepage image"
-//       />
-//     );
-//   }

--- a/src/pages/portfolio/Fylo.tsx
+++ b/src/pages/portfolio/Fylo.tsx
@@ -35,10 +35,10 @@ export function Fylo() {
                 fully&#8209;responsive. I took a mobile&#8209;first approach and
                 used modern CSS like Flexbox and Grid for layout purposes.
               </TextBlock>
-              <Tags classname="mb-0 md:mt-3 lg:mt-0 lg:mb-3">
+              <Tags className="mb-0 md:mt-3 lg:mt-0 lg:mb-3">
                 Interaction Design / Front End Development
               </Tags>
-              <Tags classname="mb-6 md:mb-4 lg:mb-7">HTML / CSS</Tags>
+              <Tags className="mb-6 md:mb-4 lg:mb-7">HTML / CSS</Tags>
               <ProjectLink to="https://www.frontendmentor.io/profile/Simplify4Me2" className="mb-6">VISIT WEBSITE</ProjectLink>
             </div>
             <TextBlock

--- a/src/pages/portfolio/Insure.tsx
+++ b/src/pages/portfolio/Insure.tsx
@@ -35,10 +35,10 @@ export function Insure() {
                 project required was to enable the toggling of the mobile
                 navigation.
               </TextBlock>
-              <Tags classname="mb-0 md:mt-3 lg:mt-0 lg:mb-3">
+              <Tags className="mb-0 md:mt-3 lg:mt-0 lg:mb-3">
                 Interaction Design / Front End Development
               </Tags>
-              <Tags classname="mb-6 md:mb-4 lg:mb-7">HTML / CSS / JS</Tags>
+              <Tags className="mb-6 md:mb-4 lg:mb-7">HTML / CSS / JS</Tags>
               <ProjectLink to="https://www.frontendmentor.io/profile/Simplify4Me2" className="mb-6">VISIT WEBSITE</ProjectLink>
             </div>
             <TextBlock

--- a/src/pages/portfolio/Manage.tsx
+++ b/src/pages/portfolio/Manage.tsx
@@ -35,10 +35,10 @@ export function Manage() {
                 JavaScript for the areas that required interactivity, such as the
                 testimonial slider.
               </TextBlock>
-              <Tags classname="mb-0 md:mt-3 lg:mt-0 lg:mb-3">
+              <Tags className="mb-0 md:mt-3 lg:mt-0 lg:mb-3">
                 Interaction Design / Front End Development
               </Tags>
-              <Tags classname="mb-6 md:mb-4 lg:mb-7">HTML / CSS / JS</Tags>
+              <Tags className="mb-6 md:mb-4 lg:mb-7">HTML / CSS / JS</Tags>
               <ProjectLink to="https://www.frontendmentor.io/profile/Simplify4Me2" className="mb-6">VISIT WEBSITE</ProjectLink>
             </div>
             <TextBlock


### PR DESCRIPTION
Fixes #5

## Problem
The `Image` component rendered three `<img>` elements and hid two with Tailwind CSS classes. The browser still fetched **all three files** regardless of which was visible — tripling image bandwidth on every device.

## Solution
Replace with the HTML5 `<picture>` element and `<source media>` attributes. The browser now fetches **only the matching breakpoint**:

```tsx
<picture>
  <source media="(min-width: 1024px)" srcSet={desktopImage} />
  <source media="(min-width: 768px)" srcSet={tabletImage} />
  <img src={mobileImage} alt={alt} className="h-fit self-center" loading="lazy" />
</picture>
```

Breakpoints match Tailwind's `lg` (1024px) and `md` (768px).

## Scope
Single change to `Image.tsx` — all 17 image wrapper components inherit the fix automatically.

Also fixes remaining `classname` → `className` callers in Fylo, Insure, and Manage (missed by the #13 fix, now surfaced as TypeScript errors).