### PR TITLE
fix: restore profile image sizing lost in picture element refactor

### DIFF
--- a/src/images/Image.tsx
+++ b/src/images/Image.tsx
@@ -3,6 +3,7 @@ type ImageProps = {
   tabletImage: string;
   desktopImage: string;
   alt: string;
+  className?: string;
 };
 
 export function Image({
@@ -10,15 +11,16 @@ export function Image({
   tabletImage,
   desktopImage,
   alt,
+  className,
 }: ImageProps) {
   return (
-    <picture>
+    <picture className={className}>
       <source media="(min-width: 1024px)" srcSet={desktopImage} />
       <source media="(min-width: 768px)" srcSet={tabletImage} />
       <img
         src={mobileImage}
         alt={alt}
-        className="h-fit self-center"
+        className="w-full h-full object-cover"
         loading="lazy"
       />
     </picture>

--- a/src/images/ProfileImage.tsx
+++ b/src/images/ProfileImage.tsx
@@ -10,6 +10,7 @@ export function ProfileImage() {
       tabletImage={TabletImage}
       desktopImage={DesktopImage}
       alt="Profile image"
+      className="self-center w-full md:w-[281px] lg:w-[540px] shrink-0"
     />
   );
 }


### PR DESCRIPTION
## What changed

- `src/images/Image.tsx` — added `className` prop forwarded to `<picture>`; changed `<img>` inner classes from `h-fit self-center` to `w-full h-full object-cover` so it fills the sized container.
- `src/images/ProfileImage.tsx` — passes `self-center w-full md:w-[281px] lg:w-[540px] shrink-0` to control sizing at each breakpoint.

## Why

PR #20 switched from separate `<img>` elements (toggled via Tailwind `hidden`/`block`) to a `<picture>` + `<source>` approach. That refactor lost the per-breakpoint width constraints that the old implementation carried on each individual `<img>`. Two bugs resulted:

1. **No width on `<picture>`** — inside the flex-row `Section`, without `shrink-0` and explicit widths the flex container shrank the picture element well below the intrinsic image size.
2. **`self-center` on the wrong element** — `align-self` is a flex-item property. The flex child is `<picture>`, not the `<img>` inside it, so the class had no effect.

The `<source>` ordering (desktop ≥1024px before tablet ≥768px) was already correct; the correct image file was loading, just displayed at the wrong size.

## Reviewer notes

- Breakpoint widths (`md:w-[281px]`, `lg:w-[540px]`) match the intrinsic pixel dimensions of the tablet and desktop profile image assets.
- `w-full` on mobile keeps the image responsive within narrower viewports.
- `object-cover` on `<img>` ensures no distortion if the container and image aspect ratios ever diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)