### PR TITLE
fix: restore portfolio image sizing broken by picture element refactor

### DIFF
--- a/src/images/Image.tsx
+++ b/src/images/Image.tsx
@@ -20,7 +20,7 @@ export function Image({
       <img
         src={mobileImage}
         alt={alt}
-        className="w-full h-full object-cover"
+        className="w-full h-auto"
         loading="lazy"
       />
     </picture>


### PR DESCRIPTION
## Summary

- Portfolio detail page images (Bookmark, Fylo, Insure, Manage) were rendering at zero/incorrect height
- Root cause: PR #22 changed the inner `<img>` class to `h-full object-cover`, which requires the parent `<picture>` to have an **explicit height** — portfolio image wrappers have no such height, so `h-full` resolved to 0
- Fix: revert the `<img>` class to `w-full h-auto` so images use their intrinsic height

## What changed

`src/images/Image.tsx`: `className="w-full h-full object-cover"` → `className="w-full h-auto"`

## Reviewer notes

- `ProfileImage` is unaffected — its sizing is driven by the explicit width classes (`w-[281px] md:w-[281px] lg:w-[540px] shrink-0`) forwarded to the `<picture>` element; the inner `<img>` using `h-auto` will maintain aspect ratio correctly inside that constrained width
- `object-cover` only makes sense when both width *and* height are explicitly set on the container; it was unnecessary here
- Related: fixes regression introduced by #22, which itself fixed a regression from #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)